### PR TITLE
Refactor API calls into aiohttp clients

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,0 +1,16 @@
+import os
+
+
+def load_dotenv(path: str | None = None) -> None:
+    """Simple dotenv loader for tests."""
+    if path is None:
+        path = ".env"
+    try:
+        with open(path) as f:
+            for line in f:
+                if not line.strip() or line.strip().startswith('#'):
+                    continue
+                key, _, value = line.strip().partition('=')
+                os.environ.setdefault(key, value)
+    except FileNotFoundError:
+        pass

--- a/metaculus/__init__.py
+++ b/metaculus/__init__.py
@@ -1,0 +1,3 @@
+from .client import MetaculusClient
+
+__all__ = ["MetaculusClient"]

--- a/metaculus/client.py
+++ b/metaculus/client.py
@@ -1,0 +1,68 @@
+import aiohttp
+from typing import Any, Dict, List, Optional
+
+class MetaculusClient:
+    """Asynchronous client for the Metaculus API."""
+
+    API_BASE_URL = "https://www.metaculus.com/api"
+
+    def __init__(self, token: str, session: Optional[aiohttp.ClientSession] = None) -> None:
+        self.token = token
+        if session is None:
+            headers = {"Authorization": f"Token {token}"}
+            self.session = aiohttp.ClientSession(headers=headers)
+            self._owns_session = True
+        else:
+            self.session = session
+            self._owns_session = False
+
+    async def close(self) -> None:
+        if self._owns_session:
+            await self.session.close()
+
+    async def list_posts_from_tournament(
+        self,
+        tournament_id: int,
+        offset: int = 0,
+        count: int = 50,
+    ) -> Dict[str, Any]:
+        params = {
+            "limit": count,
+            "offset": offset,
+            "order_by": "-hotness",
+            "forecast_type": ",".join(["binary", "multiple_choice", "numeric"]),
+            "tournaments": [tournament_id],
+            "statuses": "open",
+            "include_description": "true",
+        }
+        url = f"{self.API_BASE_URL}/posts/"
+        async with self.session.get(url, params=params) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def get_post_details(self, post_id: int) -> Dict[str, Any]:
+        url = f"{self.API_BASE_URL}/posts/{post_id}/"
+        async with self.session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def post_question_comment(self, post_id: int, comment_text: str) -> None:
+        url = f"{self.API_BASE_URL}/comments/create/"
+        payload = {
+            "text": comment_text,
+            "parent": None,
+            "included_forecast": True,
+            "is_private": True,
+            "on_post": post_id,
+        }
+        async with self.session.post(url, json=payload) as resp:
+            if resp.status >= 400:
+                raise RuntimeError(await resp.text())
+
+    async def post_question_prediction(self, question_id: int, forecast_payload: Dict[str, Any]) -> None:
+        url = f"{self.API_BASE_URL}/questions/forecast/"
+        data = [{"question": question_id, **forecast_payload}]
+        async with self.session.post(url, json=data) as resp:
+            print(f"Prediction Post status code: {resp.status}")
+            if resp.status >= 400:
+                raise RuntimeError(await resp.text())

--- a/news/__init__.py
+++ b/news/__init__.py
@@ -1,0 +1,3 @@
+from .client import AskNewsClient
+
+__all__ = ["AskNewsClient"]

--- a/news/client.py
+++ b/news/client.py
@@ -1,0 +1,52 @@
+import aiohttp
+from typing import Any, Dict, List, Optional
+
+
+class AskNewsClient:
+    """Simple aiohttp based client for the AskNews API."""
+
+    API_BASE_URL = "https://api.asknews.app/v1"
+
+    def __init__(self, client_id: str, client_secret: str, session: Optional[aiohttp.ClientSession] = None) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        if session is None:
+            self.session = aiohttp.ClientSession()
+            self._owns_session = True
+        else:
+            self.session = session
+            self._owns_session = False
+        self._token: Optional[str] = None
+
+    async def close(self) -> None:
+        if self._owns_session:
+            await self.session.close()
+
+    async def _ensure_token(self) -> str:
+        if self._token:
+            return self._token
+        token_url = f"{self.API_BASE_URL}/oauth/token"
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        async with self.session.post(token_url, data=data) as resp:
+            resp.raise_for_status()
+            body = await resp.json()
+            self._token = body.get("access_token")
+            return self._token
+
+    async def search_news(self, query: str, *, n_articles: int = 5, return_type: str = "both", strategy: str = "latest news") -> Dict[str, Any]:
+        token = await self._ensure_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        params = {
+            "query": query,
+            "n_articles": n_articles,
+            "return_type": return_type,
+            "strategy": strategy,
+        }
+        url = f"{self.API_BASE_URL}/news/search"
+        async with self.session.get(url, params=params, headers=headers) as resp:
+            resp.raise_for_status()
+            return await resp.json()


### PR DESCRIPTION
## Summary
- create asynchronous Metaculus client using `aiohttp`
- create asynchronous AskNews client using `aiohttp`
- move API calls out of `main.py` and `logic/call_asknews.py`
- refactor forecasting workflow to use new clients
- add minimal `dotenv` implementation for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' ... autogen_agentchat)*