### PR TITLE
Introduce BotConfig dataclass

### DIFF
--- a/agents/agent_creator.py
+++ b/agents/agent_creator.py
@@ -7,12 +7,11 @@ from autogen_ext.agents.openai import OpenAIAssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from openai import AsyncOpenAI
 
+from config import BotConfig
+
 from utils.PROMPTS import SPECIFIC_META_MESSAGE_EXPERTISE, EXPERTISE_ANALYZER_PROMPT, SUMMARIZATION_PROMPT
 from utils.utils import to_camel_case
 
-OPENAI_API_KEY = os.getenv(
-    "OPENAI_API_KEY")
-OPEN_AI_CLIENT = AsyncOpenAI(api_key=OPENAI_API_KEY)
 
 
 def create_agent(config: Dict[str, Any], expertise: str, specialty_expertise: str,
@@ -26,12 +25,20 @@ def create_agent(config: Dict[str, Any], expertise: str, specialty_expertise: st
 
 
 def create_openai_agent(config: Dict[str, Any], expertise: str, specialty_expertise: str,
+                       bot_config: BotConfig,
                        prompt: str = SPECIFIC_META_MESSAGE_EXPERTISE) -> OpenAIAssistantAgent:
     expertise_and_specialty_framework = f"{expertise} ({specialty_expertise})"
     name = f'{to_camel_case(expertise)}{to_camel_case(specialty_expertise)}'
     system_message = prompt.format(expertise=expertise_and_specialty_framework)
-    return OpenAIAssistantAgent(client=OPEN_AI_CLIENT, name=name, description="You are an expert forecaster",
-                                instructions=system_message, model="gpt-4.1", temperature=config["temperature"])
+    client = AsyncOpenAI(api_key=bot_config.openai_api_key)
+    return OpenAIAssistantAgent(
+        client=client,
+        name=name,
+        description="You are an expert forecaster",
+        instructions=system_message,
+        model="gpt-4.1",
+        temperature=config["temperature"],
+    )
 
 
 def create_group(agents: List) -> RoundRobinGroupChat:
@@ -42,13 +49,29 @@ def create_admin(system_message, code_execution_config: Literal[False] = False) 
     return UserProxyAgent(name="Admin", system_message=system_message, code_execution_config=code_execution_config)
 
 
-def create_summarization_assistant(config: Dict[str, Any]) -> OpenAIAssistantAgent:
-    return OpenAIAssistantAgent(name="SummarizationAgent", description="You are a summarizer",
-                                instructions=SUMMARIZATION_PROMPT, model="gpt-4.1", temperature=config["temperature"],
-                                client=OPEN_AI_CLIENT)
+def create_summarization_assistant(config: Dict[str, Any], bot_config: BotConfig) -> OpenAIAssistantAgent:
+    client = AsyncOpenAI(api_key=bot_config.openai_api_key)
+    return OpenAIAssistantAgent(
+        name="SummarizationAgent",
+        description="You are a summarizer",
+        instructions=SUMMARIZATION_PROMPT,
+        model="gpt-4.1",
+        temperature=config["temperature"],
+        client=client,
+    )
 
 
-def create_experts_analyzer_assistant(config: Dict[str, Any],
-                                      prompt: str = EXPERTISE_ANALYZER_PROMPT) -> OpenAIAssistantAgent:
-    return OpenAIAssistantAgent(name="ExpertsAnalyzerAgent", instructions=prompt, model="gpt-4.1",description="You identify well-established areas of expertise to answer a forecasting question",
-                                temperature=config["temperature"], client=OPEN_AI_CLIENT)
+def create_experts_analyzer_assistant(
+    config: Dict[str, Any],
+    bot_config: BotConfig,
+    prompt: str = EXPERTISE_ANALYZER_PROMPT,
+) -> OpenAIAssistantAgent:
+    client = AsyncOpenAI(api_key=bot_config.openai_api_key)
+    return OpenAIAssistantAgent(
+        name="ExpertsAnalyzerAgent",
+        instructions=prompt,
+        model="gpt-4.1",
+        description="You identify well-established areas of expertise to answer a forecasting question",
+        temperature=config["temperature"],
+        client=client,
+    )

--- a/agents/asknews_scrapper.py
+++ b/agents/asknews_scrapper.py
@@ -1,14 +1,18 @@
-import os
 from typing import List, Literal
+
+from config import BotConfig
 
 from asknews_sdk import AskNewsSDK
 
 
 
 class AskNewsScrapper:
-    def __init__(self, scopes: List[Literal["news"]] = ["news"]):
-        self._ask_news_engine = AskNewsSDK(client_id=os.getenv("ASKNEWS_CLIENT_ID"),
-                                           client_secret=os.getenv("ASKNEWS_SECRET"), scopes=scopes)
+    def __init__(self, bot_config: BotConfig, scopes: List[Literal["news"]] = ["news"]):
+        self._ask_news_engine = AskNewsSDK(
+            client_id=bot_config.asknews_client_id,
+            client_secret=bot_config.asknews_secret,
+            scopes=scopes,
+        )
 
     def get_latest_news(self, query: str, n_articles: int):
         return self._ask_news_engine.news.search_news(

--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+import os
+
+@dataclass
+class BotConfig:
+    submit_prediction: bool
+    use_example_questions: bool
+    skip_previously_forecasted_questions: bool
+    metaculus_token: str | None
+    asknews_client_id: str | None
+    asknews_secret: str | None
+    openai_api_key: str | None
+
+    @classmethod
+    def from_env(cls) -> "BotConfig":
+        return cls(
+            submit_prediction=os.getenv("SUBMIT_PREDICTION", "false").lower() == "true",
+            use_example_questions=os.getenv("USE_EXAMPLE_QUESTIONS", "false").lower() == "true",
+            skip_previously_forecasted_questions=os.getenv("SKIP_PREVIOUSLY_FORECASTED_QUESTIONS", "false").lower() == "true",
+            metaculus_token=os.getenv("METACULUS_TOKEN"),
+            asknews_client_id=os.getenv("ASKNEWS_CLIENT_ID"),
+            asknews_secret=os.getenv("ASKNEWS_SECRET"),
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+        )

--- a/main_test.py
+++ b/main_test.py
@@ -6,11 +6,14 @@ import re
 from random import randint
 from time import sleep
 
-import dotenv
+try:
+    import dotenv
+    dotenv.load_dotenv()
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    dotenv = None
 
 from logic.forecast_single_question import forecast_single_binary_question, forecast_single_multiple_choice_question
 
-dotenv.load_dotenv()
 
 from openai import AsyncOpenAI
 import numpy as np

--- a/tests/test_end_2_end.py
+++ b/tests/test_end_2_end.py
@@ -2,7 +2,7 @@ import random
 import unittest
 import datetime
 
-from main import forecast_questions
+from main import forecast_questions, BOT_CONFIG
 
 class TestEnd2End(unittest.IsolatedAsyncioTestCase):
 
@@ -10,12 +10,13 @@ class TestEnd2End(unittest.IsolatedAsyncioTestCase):
         open_question_id_post_id = [(578, 578)]
         now = datetime.datetime.now()
         await forecast_questions(
-                open_question_id_post_id,
-                submit_prediction=True,
-                skip_previously_forecasted_questions=False,
-                use_hyde=True,
-                cache_seed=42
-            )
+            open_question_id_post_id,
+            submit_prediction=True,
+            skip_previously_forecasted_questions=False,
+            config=BOT_CONFIG,
+            use_hyde=True,
+            cache_seed=42,
+        )
         print(f"time taken to run: {datetime.datetime.now() - now}")
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,16 +1,22 @@
-import os
 from typing import Dict, Any
 
+from config import BotConfig
 
 
-def get_gpt_config(cache_seed: int, temperature: float, model: str, timeout: int) -> Dict[str, Any]:
+
+def get_gpt_config(cache_seed: int, temperature: float, model: str, timeout: int,
+                   bot_config: BotConfig) -> Dict[str, Any]:
+    """Build an LLM config using the API key from ``bot_config``."""
+
     return {
         "cache_seed": cache_seed,
         "temperature": temperature,
         "config_list": [
-            {"model": model, "api_key": os.environ.get("OPENAI_API_KEY"),
-             "response_format": {"type": "json_object"},
-             }
+            {
+                "model": model,
+                "api_key": bot_config.openai_api_key,
+                "response_format": {"type": "json_object"},
+            }
         ],
         "timeout": timeout,
     }

--- a/utils/query_builder.py
+++ b/utils/query_builder.py
@@ -5,14 +5,18 @@ from autogen import AssistantAgent
 from main import CACHE_SEED
 from utils.PROMPTS import KEYWORDS_PROMPT
 from utils.config import get_gpt_config
+from config import BotConfig
 
 
 class QuestionToQuery:
-    def __init__(self):
+    def __init__(self, bot_config: BotConfig):
 
-        self._agent = AssistantAgent(name="KeywordAgent", system_message=KEYWORDS_PROMPT, llm_config=get_gpt_config(
-            CACHE_SEED, 0.7, "gpt-4o", 120),
-                                     human_input_mode="NEVER")
+        self._agent = AssistantAgent(
+            name="KeywordAgent",
+            system_message=KEYWORDS_PROMPT,
+            llm_config=get_gpt_config(CACHE_SEED, 0.7, "gpt-4o", 120, bot_config),
+            human_input_mode="NEVER",
+        )
 
     def _create_messages(self,question):
         return [


### PR DESCRIPTION
## Summary
- add new `BotConfig` dataclass to centralize environment configuration
- update helpers to build LLM configs with `BotConfig`
- refactor logic modules and agents to accept `BotConfig`
- use `BotConfig` in `main.py` and tests
- make optional imports safe when dependencies are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*