### PR TITLE
Add offline forecasting workflows

### DIFF
--- a/.github/workflows/offline_run_bot.yaml
+++ b/.github/workflows/offline_run_bot.yaml
@@ -1,0 +1,43 @@
+name: Offline forecast run
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  offline_forecast:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Run offline bot
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          poetry run python offline_main.py

--- a/.github/workflows/offline_wisdom_of_crowds.yaml
+++ b/.github/workflows/offline_wisdom_of_crowds.yaml
@@ -1,0 +1,43 @@
+name: Offline wisdom of crowds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  offline_woc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Run offline wisdom of crowds
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          poetry run python offline_wisdom_of_crowds.py

--- a/logic/offline/forecaster.py
+++ b/logic/offline/forecaster.py
@@ -1,0 +1,101 @@
+import asyncio
+import json
+from typing import List, Dict, Tuple, Union
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+from agents.agent_creator import create_group, create_summarization_assistant
+from logic.summarization import run_summarization_phase
+from logic.chat import validate_and_parse_response
+from logic.utils import (
+    extract_question_details,
+    perform_forecasting_phase,
+    perform_revised_forecasting_step,
+    strip_title_to_filename,
+    build_and_write_json,
+    get_probabilities,
+    enrich_probabilities,
+    get_first_phase_probabilities,
+    get_relevant_contexts_to_group_discussion,
+)
+from utils.PROMPTS import GROUP_INSTRUCTIONS
+from utils.config import get_gpt_config
+
+
+def _create_offline_agent(name: str) -> AssistantAgent:
+    client = OpenAIChatCompletionClient(model="gpt-4.1", temperature=1)
+    system_message = f"You are {name}, an expert forecaster."
+    agent = AssistantAgent(name=name, system_message=system_message, model_client=client)
+    agent.display_name = name
+    return agent
+
+
+async def chat_group_single_question_offline(
+    question_details: dict,
+    news: str,
+    expert_names: List[str],
+    cache_seed: int = 42,
+    is_multiple_choice: bool = False,
+    options: List[str] | None = None,
+    is_woc: bool = False,
+) -> Tuple[Union[int, Dict[str, float]], str]:
+    title, description, fine_print, resolution_criteria, forecast_date = extract_question_details(question_details)
+    config = get_gpt_config(cache_seed, 1, "gpt-4.1", 120)
+
+    experts = [_create_offline_agent(name) for name in expert_names]
+    group_chat = create_group(experts)
+
+    results = await perform_forecasting_phase(experts, question_details, news=news,
+                                              is_multiple_choice=is_multiple_choice, options=options)
+
+    group_contextualization = get_relevant_contexts_to_group_discussion(results)
+    probabilities = get_first_phase_probabilities(results, is_multiple_choice, options)
+
+    group_results = await group_chat.run(
+        task=GROUP_INSTRUCTIONS.format(phase1_results_json_string=group_contextualization,
+                                       forecasters_list=expert_names))
+
+    parsed_group_results = {
+        answer.source: validate_and_parse_response(answer.content)
+        for answer in group_results.messages if answer.source != "user"
+    }
+
+    revision_results = await perform_revised_forecasting_step(
+        experts, question_details, news=news,
+        is_multiple_choice=is_multiple_choice, options=options
+    )
+
+    summarization_assistant = create_summarization_assistant(config)
+    summarization = await run_summarization_phase(results, question_details, summarization_assistant)
+
+    probabilities = get_probabilities(results, revision_results, parsed_group_results,
+                                      is_multiple_choice, options, probabilities)
+
+    enrich_probabilities(probabilities, question_details, news, forecast_date, summarization, expert_names)
+
+    final_answer = probabilities["revision_probability_result"]
+
+    filename = strip_title_to_filename(title) + "_offline"
+    await build_and_write_json(filename, probabilities, is_woc)
+
+    return final_answer, summarization
+
+
+async def forecast_from_json(path: str, is_woc: bool = False, cache_seed: int = 42) -> None:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    question_details = data.get("question_details", {})
+    news = data.get("news", "")
+    expert_names = list(data.get("results", {}).keys())
+
+    await chat_group_single_question_offline(
+        question_details=question_details,
+        news=news,
+        expert_names=expert_names,
+        cache_seed=cache_seed,
+        is_multiple_choice=question_details.get("type") == "multiple_choice",
+        options=question_details.get("options"),
+        is_woc=is_woc,
+    )

--- a/offline_main.py
+++ b/offline_main.py
@@ -1,0 +1,16 @@
+import asyncio
+import os
+
+from logic.offline.forecaster import forecast_from_json
+
+FORECAST_DIR = "forecasts"
+
+
+async def main() -> None:
+    files = [f for f in os.listdir(FORECAST_DIR) if f.endswith(".json")]
+    for file in files:
+        await forecast_from_json(os.path.join(FORECAST_DIR, file), is_woc=False)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/offline_wisdom_of_crowds.py
+++ b/offline_wisdom_of_crowds.py
@@ -1,0 +1,16 @@
+import asyncio
+import os
+
+from logic.offline.forecaster import forecast_from_json
+
+FORECAST_DIR = "forecasts"
+
+
+async def main() -> None:
+    files = [f for f in os.listdir(FORECAST_DIR) if f.endswith(".json")]
+    for file in files:
+        await forecast_from_json(os.path.join(FORECAST_DIR, file), is_woc=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add new offline forecaster module
- add scripts to run forecasts and wisdom of crowds using local JSON data only
- schedule new GitHub Actions workflows to execute these offline scripts nightly

## Testing
- `python -m py_compile offline_main.py offline_wisdom_of_crowds.py logic/offline/forecaster.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6855769cff90832bac0e5cd720a249e0