### PR TITLE
Add centralized settings loader

### DIFF
--- a/agents/agent_creator.py
+++ b/agents/agent_creator.py
@@ -1,5 +1,6 @@
-import os
 from typing import Dict, Any, Literal, List
+
+from settings import settings
 
 from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
 from autogen_agentchat.teams import RoundRobinGroupChat
@@ -10,8 +11,7 @@ from openai import AsyncOpenAI
 from utils.PROMPTS import SPECIFIC_META_MESSAGE_EXPERTISE, EXPERTISE_ANALYZER_PROMPT, SUMMARIZATION_PROMPT
 from utils.utils import to_camel_case
 
-OPENAI_API_KEY = os.getenv(
-    "OPENAI_API_KEY")
+OPENAI_API_KEY = settings.openai_api_key
 OPEN_AI_CLIENT = AsyncOpenAI(api_key=OPENAI_API_KEY)
 
 

--- a/agents/asknews_scrapper.py
+++ b/agents/asknews_scrapper.py
@@ -1,5 +1,6 @@
-import os
 from typing import List, Literal
+
+from settings import settings
 
 from asknews_sdk import AskNewsSDK
 
@@ -7,8 +8,8 @@ from asknews_sdk import AskNewsSDK
 
 class AskNewsScrapper:
     def __init__(self, scopes: List[Literal["news"]] = ["news"]):
-        self._ask_news_engine = AskNewsSDK(client_id=os.getenv("ASKNEWS_CLIENT_ID"),
-                                           client_secret=os.getenv("ASKNEWS_SECRET"), scopes=scopes)
+        self._ask_news_engine = AskNewsSDK(client_id=settings.asknews_client_id,
+                                           client_secret=settings.asknews_secret, scopes=scopes)
 
     def get_latest_news(self, query: str, n_articles: int):
         return self._ask_news_engine.news.search_news(

--- a/logic/call_asknews.py
+++ b/logic/call_asknews.py
@@ -1,6 +1,7 @@
 import asyncio
-import os
 from typing import Dict
+
+from settings import settings
 
 from asknews_sdk import AskNewsSDK
 from autogen_agentchat.agents import AssistantAgent
@@ -10,8 +11,8 @@ from logic.chat import validate_and_parse_response
 from logic.utils import extract_question_details
 from utils.PROMPTS import HYDE_PROMPT
 
-ASKNEWS_CLIENT_ID = os.getenv("ASKNEWS_CLIENT_ID")
-ASKNEWS_SECRET = os.getenv("ASKNEWS_SECRET")
+ASKNEWS_CLIENT_ID = settings.asknews_client_id
+ASKNEWS_SECRET = settings.asknews_secret
 
 
 async def run_research(question: Dict[str, str], use_hyde: bool = True) -> str:

--- a/main.py
+++ b/main.py
@@ -2,15 +2,14 @@ import asyncio
 import datetime
 import json
 import logging
-import os
 
-import dotenv
+from settings import settings
 
 from logic.chat_group_single_question import chat_group_single_question
-from logic.forecast_single_question import \
-    forecast_single_question
+from logic.forecast_single_question import (
+    forecast_single_question,
+)
 from forecasting_tools import MetaculusApi
-dotenv.load_dotenv()
 
 import requests
 
@@ -26,15 +25,14 @@ GET_NEWS = True  # set to True to enable the bot to do online research
 
 # Environment variables
 
-SUBMIT_PREDICTION = True if os.getenv("SUBMIT_PREDICTION") == "true" else False
-USE_EXAMPLE_QUESTIONS = True if os.getenv("USE_EXAMPLE_QUESTIONS") == "true" else False
-SKIP_PREVIOUSLY_FORECASTED_QUESTIONS = True if os.getenv("SKIP_PREVIOUSLY_FORECASTED_QUESTIONS") == "true" else False
+SUBMIT_PREDICTION = settings.submit_prediction
+USE_EXAMPLE_QUESTIONS = settings.use_example_questions
+SKIP_PREVIOUSLY_FORECASTED_QUESTIONS = settings.skip_previously_forecasted_questions
 
-METACULUS_TOKEN = os.getenv("METACULUS_TOKEN")
-ASKNEWS_CLIENT_ID = os.getenv("ASKNEWS_CLIENT_ID")
-ASKNEWS_SECRET = os.getenv("ASKNEWS_SECRET")
-OPENAI_API_KEY = os.getenv(
-    "OPENAI_API_KEY")
+METACULUS_TOKEN = settings.metaculus_token
+ASKNEWS_CLIENT_ID = settings.asknews_client_id
+ASKNEWS_SECRET = settings.asknews_secret
+OPENAI_API_KEY = settings.openai_api_key
 
 # The tournament IDs below can be used for testing your bot.
 Q4_2024_AI_BENCHMARKING_ID = 32506

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+import os
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback if dotenv isn't installed
+    def load_dotenv() -> None:  # type: ignore
+        return None
+
+
+def _get_bool(name: str) -> bool:
+    return os.getenv(name, "false").lower() == "true"
+
+
+@dataclass
+class Settings:
+    submit_prediction: bool
+    use_example_questions: bool
+    skip_previously_forecasted_questions: bool
+    metaculus_token: str | None
+    asknews_client_id: str | None
+    asknews_secret: str | None
+    openai_api_key: str | None
+
+
+def load_settings() -> Settings:
+    load_dotenv()
+    return Settings(
+        submit_prediction=_get_bool("SUBMIT_PREDICTION"),
+        use_example_questions=_get_bool("USE_EXAMPLE_QUESTIONS"),
+        skip_previously_forecasted_questions=_get_bool("SKIP_PREVIOUSLY_FORECASTED_QUESTIONS"),
+        metaculus_token=os.getenv("METACULUS_TOKEN"),
+        asknews_client_id=os.getenv("ASKNEWS_CLIENT_ID"),
+        asknews_secret=os.getenv("ASKNEWS_SECRET"),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+    )
+
+settings = load_settings()
+

--- a/wisdom_of_crowds.py
+++ b/wisdom_of_crowds.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import List, Tuple
 
+from settings import settings
+
 import asyncio
 import logging
 


### PR DESCRIPTION
## Summary
- add `settings` module with a dataclass for configuration
- refactor modules to use `settings` instead of directly reading env vars
- ensure `load_dotenv` is optional when not installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6855a0865a38832b92956888cf9220c3